### PR TITLE
Update link to newer version of BattlesnakeTester

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,6 @@ templates that haven't made that list.
 ## Miscellaneous
 
 - [cbinners/battlesnake-download-tool](https://github.com/cbinners/battlesnake-download-tool) (Chrome Extension to download game states for Battlesnake)
-- [devinc13/BattlesnakeTester](https://github.com/devinc13/BattlesnakeTester) (Smoke tests for Battlesnake behaviour)
 - [lworkman/battle-snake-board-generator](https://github.com/lworkman/battle-snake-board-generator) (A quick and dirty react-typescript app for battlesnake testing)
+- [niecore/BattlesnakeTester](https://github.com/niecore/BattlesnakeTester) (Smoke tests for Battlesnake behaviour)
 - [Stats Tracker](https://lajeunesse.dev:3000/login) (Dashboard to follow your snake rating throughout time. Username/password: tester)


### PR DESCRIPTION
Hey @xtagon !

I noticed that [devinc13/BattlesnakeTester](https://github.com/devinc13/BattlesnakeTester) hasn't been updated since 2018 and that @niecore forked and updated the code in 2019 [niecore/BattlesnakeTester](https://github.com/niecore/BattlesnakeTester). 

This code is more recent; however, it is still not up to date with the latest Battlesnake API version. 
I thought I would create a pull request to update the link to this new repository.

Thank You,
@md-hexdrive