### PR TITLE
Link to new BattleSnake game downloader CLI tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ community have decided to share that they use for their snakes. Juicy secrets!
 
 - [Battlesnake Downloader](https://addons.mozilla.org/en-GB/firefox/addon/battlesnake-downloader/) (Firefox extension to download battlesnake games)
 - [cbinners/battlesnake-download-tool](https://github.com/cbinners/battlesnake-download-tool) (Chrome Extension to download game states for Battlesnake)
+- [BattleSnake game downloader](https://github.com/TheApX/battlesnake-engine-cpp/tree/main/gamedownloader) (CLI tool to download battlesnake games in json format that can be sent directly to your battlesnake)
 - [joshhartmann11/BattleSnakeArena](https://github.com/joshhartmann11/BattleSnakeArena) (A modified, terminal based, battle snake arena to bypass servers and have complete access to data)
 - [lworkman/battle-snake-board-generator](https://github.com/lworkman/battle-snake-board-generator) (A quick and dirty react-typescript app for battlesnake testing)
 - [Nettogrof/battle-snake-board-generator](https://github.com/Nettogrof/battle-snake-board-generator) (A fork based on lworkman's board generator, with some awesome updates)


### PR DESCRIPTION
Even though `BattleSnake game downloader` is lexicographically higher than `cbinners/battlesnake-download-tool`, I've placed it below because:
* It makes sense to list browser extensions together.
* Browser extensions are easier to use than a hardcore CLI tool and thus should be listed first.
* `battlesnake-download-tool` is lexicographically higher if we ignore case and consider dashes equal to spaces :)