### PR TITLE
Add symbols

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Contributions welcome! Read the [contribution guidelines](CONTRIBUTING.md) first
 
 ## Meaning of symbols
 
+🌟 - The project is recommended by the community
+
 🔨 - The project is actively maintained
 
 ## Contents

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ Contributions welcome! Read the [contribution guidelines](CONTRIBUTING.md) first
 
 ## Contents
 
-
 - [Battlesnakes](#battlesnakes)
 - [Developer Stories](#developer-stories)
 - [Game Rules and Logic](#game-rules-and-logic)
@@ -124,6 +123,7 @@ Contributions welcome! Read the [contribution guidelines](CONTRIBUTING.md) first
 
 - [ArthurFirmino/Gym-Battlesnake](https://github.com/ArthurFirmino/gym-battlesnake) `C++` - Multi-agent reinforcement learning environment
 - [Battlesnake Post Mortem by Asymptotic Labs](https://medium.com/asymptoticlabs/battlesnake-post-mortem-a5917f9a3428) - Using a desktop GPU to top the global arena in under a week
+- [DaBultz/pz-battlesnake](https://github.com/DaBultz/pz-battlesnake) `🔨 Go/Python` - PettingZoo/Gym Multi-Agent Environment For Battlesnake
 - [Exploring Data From Battlesnake Tournament Games](https://medium.com/battlesnake/exploring-battlesnake-game-data-4daa0d9fdd9) - Article exploring various stats across all games run during the 2019 Battlesnake Victoria Tournament
 - [NNUE-Pytorch](https://github.com/glinscott/nnue-pytorch/blob/master/docs/nnue.md) `Python` - "Efficiently Updatable Neural Network" explained in the context of chess
 - [Rainyforest/battlesnake_2020](https://github.com/Rainyforest/battlesnake_2020) `Python` - Simple environment for machine learning training, and A\* for food finding

--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@
 
 Contributions welcome! Read the [contribution guidelines](CONTRIBUTING.md) first.
 
+## Meaning of symbols
+
+🌟 - The project is recommended by the community
+
+🔨 - The project is actively maintained
+
 ## Contents
 
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@ Contributions welcome! Read the [contribution guidelines](CONTRIBUTING.md) first
 
 ## Meaning of symbols
 
-🌟 - The project is recommended by the community
-
 🔨 - The project is actively maintained
 
 ## Contents

--- a/README.md
+++ b/README.md
@@ -125,7 +125,6 @@ Contributions welcome! Read the [contribution guidelines](CONTRIBUTING.md) first
 
 - [ArthurFirmino/Gym-Battlesnake](https://github.com/ArthurFirmino/gym-battlesnake) `C++` - Multi-agent reinforcement learning environment
 - [Battlesnake Post Mortem by Asymptotic Labs](https://medium.com/asymptoticlabs/battlesnake-post-mortem-a5917f9a3428) - Using a desktop GPU to top the global arena in under a week
-- [DaBultz/pz-battlesnake](https://github.com/DaBultz/pz-battlesnake) `🔨 Go/Python` - PettingZoo/Gym Multi-Agent Environment For Battlesnake
 - [Exploring Data From Battlesnake Tournament Games](https://medium.com/battlesnake/exploring-battlesnake-game-data-4daa0d9fdd9) - Article exploring various stats across all games run during the 2019 Battlesnake Victoria Tournament
 - [NNUE-Pytorch](https://github.com/glinscott/nnue-pytorch/blob/master/docs/nnue.md) `Python` - "Efficiently Updatable Neural Network" explained in the context of chess
 - [Rainyforest/battlesnake_2020](https://github.com/Rainyforest/battlesnake_2020) `Python` - Simple environment for machine learning training, and A\* for food finding


### PR DESCRIPTION
I've opened this as a draft pull request, while it's worked on.

It was requested in PR #22 that adding the symbols should be turned into a separate PR or multiple, as it takes some consideration, so for now, I've only added the legend back.

Here is how I'm thinking we could do it:

1) The legend is added + some guidelines (i.e when the symbols is added/removed)

2) A second PR is made, in which we try and update the list
2.1) Maintainers is able to let us know, that their project is maintained


This has the benefit of:
- New PR's can get the symbols 
- Developers adding their project can add the maintained symbol 
- Existing developers, can open a PR adding the maintained symbol to their projects 

I think, this approach is one of the simpler ways of doing it and when it's done. maintaining would be kept simple.  